### PR TITLE
Checking if the table exists when dropping it.

### DIFF
--- a/server/src/main/resources/liquibase/db.changelog.xml
+++ b/server/src/main/resources/liquibase/db.changelog.xml
@@ -2111,7 +2111,7 @@
     <changeSet id="05.05.21-11:48" author="seva" context="common">
         <comment>Drop legacy licensing data</comment>
         <sql>
-            DROP TABLE plugin_licensing_settings;
+            DROP TABLE IF EXISTS plugin_licensing_settings;
             DELETE FROM plugins WHERE identifier='licensing';
         </sql>
         <rollback>


### PR DESCRIPTION
Table "plugin_licensing_settings" is not created by the migrations.
This leads to an error when launching application on an empty database, preventing the application from starting.

Logs before fix:
```
08-May-2021 02:48:32.552 INFO [http-nio-8080-exec-2] com.google.inject.internal.MessageProcessor.visit 
An exception was caught and reported. Message: org.postgresql.util.PSQLException: 
ERROR: table "plugin_licensing_settings" does not exist
	java.lang.RuntimeException: liquibase.exception.MigrationFailedException: 
        Migration failed for change set db.changelog.xml::05.05.21-11:48::seva: Reason: liquibase.exception.DatabaseException: 
        ERROR: table "plugin_licensing_settings" does not exist [Failed SQL: DROP TABLE plugin_licensing_settings]
		at com.hmdm.guice.module.AbstractLiquibaseModule.configure(AbstractLiquibaseModule.java:78)
```

Logs after fix:
```
2021-05-08 05:04:05 [INFO] liquibase.executor.jvm.JdbcExecutor : DROP TABLE IF EXISTS plugin_licensing_settings
2021-05-08 05:04:05 [INFO] liquibase.executor.jvm.JdbcExecutor : DELETE FROM plugins WHERE identifier='licensing'
2021-05-08 05:04:05 [INFO] liquibase.changelog.ChangeSet : Custom SQL executed
2021-05-08 05:04:05 [INFO] liquibase.changelog.ChangeSet : ChangeSet db.changelog.xml::05.05.21-11:48::seva ran successfully in 6ms
```