### PR TITLE
Extra permissions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,1 @@
+{"image":"mcr.microsoft.com/devcontainers/universal:2"}

--- a/common/src/main/java/com/hmdm/persistence/domain/Configuration.java
+++ b/common/src/main/java/com/hmdm/persistence/domain/Configuration.java
@@ -150,8 +150,8 @@ public class Configuration implements CustomerData, Serializable {
     private String qrParameters;
     @ApiModelProperty("Prefer mobile data for provisioning")
     private boolean mobileEnrollment;
-    @ApiModelProperty("Require additional permissions")
-    private boolean mobileRequireAdditionalPermissions;
+    @ApiModelProperty("Skip permissions that require user interaction")
+    private Boolean skipUserInteractivePermissions;
     @ApiModelProperty("Flag enabling Home button in kiosk mode")
     private Boolean kioskHome;
     @ApiModelProperty("Flag enabling Recents button in kiosk mode")

--- a/common/src/main/java/com/hmdm/persistence/domain/Configuration.java
+++ b/common/src/main/java/com/hmdm/persistence/domain/Configuration.java
@@ -442,12 +442,12 @@ public class Configuration implements CustomerData, Serializable {
         this.mobileEnrollment = mobileEnrollment;
     }
 
-    public boolean isMobileRequireAdditionalPermissions() {
-        return mobileRequireAdditionalPermissions;
+    public boolean getSkipUserInteractivePermissions() {
+        return skipUserInteractivePermissions;
     }
 
-    public void setMobileRequireAdditionalPermissions(boolean mobileRequireAdditionalPermissions) {
-        this.mobileRequireAdditionalPermissions = mobileRequireAdditionalPermissions;
+    public void setSkipUserInteractivePermissions(boolean skipUserInteractivePermissions) {
+        this.skipUserInteractivePermissions = skipUserInteractivePermissions;
     }
 
     public Boolean getKioskHome() {

--- a/common/src/main/java/com/hmdm/persistence/domain/Configuration.java
+++ b/common/src/main/java/com/hmdm/persistence/domain/Configuration.java
@@ -770,6 +770,7 @@ public class Configuration implements CustomerData, Serializable {
         this.lockSafeSettings = lockSafeSettings;
     }
 
+    
     public Boolean getPermissive() {
         return permissive;
     }

--- a/common/src/main/java/com/hmdm/persistence/domain/Configuration.java
+++ b/common/src/main/java/com/hmdm/persistence/domain/Configuration.java
@@ -150,6 +150,8 @@ public class Configuration implements CustomerData, Serializable {
     private String qrParameters;
     @ApiModelProperty("Prefer mobile data for provisioning")
     private boolean mobileEnrollment;
+    @ApiModelProperty("Require additional permissions")
+    private boolean mobileRequireAdditionalPermissions;
     @ApiModelProperty("Flag enabling Home button in kiosk mode")
     private Boolean kioskHome;
     @ApiModelProperty("Flag enabling Recents button in kiosk mode")
@@ -438,6 +440,14 @@ public class Configuration implements CustomerData, Serializable {
 
     public void setMobileEnrollment(boolean mobileEnrollment) {
         this.mobileEnrollment = mobileEnrollment;
+    }
+
+    public boolean isMobileRequireAdditionalPermissions() {
+        return mobileRequireAdditionalPermissions;
+    }
+
+    public void setMobileRequireAdditionalPermissions(boolean mobileRequireAdditionalPermissions) {
+        this.mobileRequireAdditionalPermissions = mobileRequireAdditionalPermissions;
     }
 
     public Boolean getKioskHome() {

--- a/common/src/main/java/com/hmdm/persistence/mapper/ConfigurationMapper.java
+++ b/common/src/main/java/com/hmdm/persistence/mapper/ConfigurationMapper.java
@@ -108,7 +108,7 @@ public interface ConfigurationMapper {
             "wifiSecurityType=#{wifiSecurityType}, " +
             "qrParameters=#{qrParameters}, " +
             "mobileEnrollment=#{mobileEnrollment}, " +
-            "mobileRequireAdditionalPermissions=#{mobileRequireAdditionalPermissions}, " +
+            "skipUserInteractivePermissions=#{skipUserInteractivePermissions}, " +
             "kioskHome=#{kioskHome}, " +
             "kioskRecents=#{kioskRecents}, " +
             "kioskNotifications=#{kioskNotifications}, " +

--- a/common/src/main/java/com/hmdm/persistence/mapper/ConfigurationMapper.java
+++ b/common/src/main/java/com/hmdm/persistence/mapper/ConfigurationMapper.java
@@ -108,6 +108,7 @@ public interface ConfigurationMapper {
             "wifiSecurityType=#{wifiSecurityType}, " +
             "qrParameters=#{qrParameters}, " +
             "mobileEnrollment=#{mobileEnrollment}, " +
+            "mobileRequireAdditionalPermissions=#{mobileRequireAdditionalPermissions}, " +
             "kioskHome=#{kioskHome}, " +
             "kioskRecents=#{kioskRecents}, " +
             "kioskNotifications=#{kioskNotifications}, " +

--- a/common/src/main/java/com/hmdm/persistence/mapper/ConfigurationMapper.xml
+++ b/common/src/main/java/com/hmdm/persistence/mapper/ConfigurationMapper.xml
@@ -31,7 +31,7 @@
                                     lockVolume, manageVolume, volume, passwordMode, orientation,
                                     runDefaultLauncher, disableScreenshots, autostartForeground, timeZone, allowedClasses, newServerUrl,
                                     lockSafeSettings, permissive, kioskExit, showWifi, mainAppId, eventReceivingComponent, kioskMode,
-                                    contentAppId, wifiSSID, wifiPassword, wifiSecurityType, qrParameters, mobileEnrollment, mobileRequireAdditionalPermissions, kioskHome, kioskRecents,
+                                    contentAppId, wifiSSID, wifiPassword, wifiSecurityType, qrParameters, mobileEnrollment, skipUserInteractivePermissions, kioskHome, kioskRecents,
                                     kioskNotifications, kioskSystemInfo, kioskKeyguard, kioskLockButtons, restrictions, autoUpdate,
                                     blockStatusBar, systemUpdateType, systemUpdateFrom, systemUpdateTo,
                                     scheduleAppUpdate, appUpdateFrom, appUpdateTo, defaultFilePath)
@@ -42,7 +42,7 @@
                 #{lockVolume}, #{manageVolume}, #{volume}, #{passwordMode}, #{orientation},
                 #{runDefaultLauncher}, #{disableScreenshots}, #{autostartForeground}, #{timeZone}, #{allowedClasses}, #{newServerUrl},
                 #{lockSafeSettings}, #{permissive}, #{kioskExit}, #{showWifi}, #{mainAppId}, #{eventReceivingComponent}, #{kioskMode},
-                #{contentAppId}, #{wifiSSID}, #{wifiPassword}, #{wifiSecurityType}, #{qrParameters}, #{mobileEnrollment}, #{mobileRequireAdditionalPermissions}, #{kioskHome}, #{kioskRecents},
+                #{contentAppId}, #{wifiSSID}, #{wifiPassword}, #{wifiSecurityType}, #{qrParameters}, #{mobileEnrollment}, #{skipUserInteractivePermissions}, #{kioskHome}, #{kioskRecents},
                 #{kioskNotifications}, #{kioskSystemInfo}, #{kioskKeyguard}, #{kioskLockButtons}, #{restrictions}, #{autoUpdate},
                 #{blockStatusBar}, #{systemUpdateType}, #{systemUpdateFrom}, #{systemUpdateTo},
                 #{scheduleAppUpdate}, #{appUpdateFrom}, #{appUpdateTo}, #{defaultFilePath})

--- a/common/src/main/java/com/hmdm/persistence/mapper/ConfigurationMapper.xml
+++ b/common/src/main/java/com/hmdm/persistence/mapper/ConfigurationMapper.xml
@@ -31,7 +31,7 @@
                                     lockVolume, manageVolume, volume, passwordMode, orientation,
                                     runDefaultLauncher, disableScreenshots, autostartForeground, timeZone, allowedClasses, newServerUrl,
                                     lockSafeSettings, permissive, kioskExit, showWifi, mainAppId, eventReceivingComponent, kioskMode,
-                                    contentAppId, wifiSSID, wifiPassword, wifiSecurityType, qrParameters, mobileEnrollment, kioskHome, kioskRecents,
+                                    contentAppId, wifiSSID, wifiPassword, wifiSecurityType, qrParameters, mobileEnrollment, mobileRequireAdditionalPermissions, kioskHome, kioskRecents,
                                     kioskNotifications, kioskSystemInfo, kioskKeyguard, kioskLockButtons, restrictions, autoUpdate,
                                     blockStatusBar, systemUpdateType, systemUpdateFrom, systemUpdateTo,
                                     scheduleAppUpdate, appUpdateFrom, appUpdateTo, defaultFilePath)
@@ -42,7 +42,7 @@
                 #{lockVolume}, #{manageVolume}, #{volume}, #{passwordMode}, #{orientation},
                 #{runDefaultLauncher}, #{disableScreenshots}, #{autostartForeground}, #{timeZone}, #{allowedClasses}, #{newServerUrl},
                 #{lockSafeSettings}, #{permissive}, #{kioskExit}, #{showWifi}, #{mainAppId}, #{eventReceivingComponent}, #{kioskMode},
-                #{contentAppId}, #{wifiSSID}, #{wifiPassword}, #{wifiSecurityType}, #{qrParameters}, #{mobileEnrollment}, #{kioskHome}, #{kioskRecents},
+                #{contentAppId}, #{wifiSSID}, #{wifiPassword}, #{wifiSecurityType}, #{qrParameters}, #{mobileEnrollment}, #{mobileRequireAdditionalPermissions}, #{kioskHome}, #{kioskRecents},
                 #{kioskNotifications}, #{kioskSystemInfo}, #{kioskKeyguard}, #{kioskLockButtons}, #{restrictions}, #{autoUpdate},
                 #{blockStatusBar}, #{systemUpdateType}, #{systemUpdateFrom}, #{systemUpdateTo},
                 #{scheduleAppUpdate}, #{appUpdateFrom}, #{appUpdateTo}, #{defaultFilePath})

--- a/server/src/main/java/com/hmdm/rest/json/SyncResponse.java
+++ b/server/src/main/java/com/hmdm/rest/json/SyncResponse.java
@@ -761,12 +761,12 @@ public class SyncResponse implements Serializable, SyncResponseInt {
         this.lockSafeSettings = lockSafeSettings;
     }
 
-    public void setMobileRequireAdditionalPermissions(boolean mobileRequireAdditionalPermissions) {
-        this.mobileRequireAdditionalPermissions = mobileRequireAdditionalPermissions;
+    public void setSkipUserInteractivePermissions(boolean skipUserInteractivePermissions) {
+        this.skipUserInteractivePermissions = skipUserInteractivePermissions;
     }
 
-    public Boolean getMobileRequireAdditionalPermissions() {
-        return mobileRequireAdditionalPermissions;
+    public Boolean getSkipUserInteractivePermissions() {
+        return skipUserInteractivePermissions;
     }
 
     @Override

--- a/server/src/main/java/com/hmdm/rest/json/SyncResponse.java
+++ b/server/src/main/java/com/hmdm/rest/json/SyncResponse.java
@@ -121,8 +121,8 @@ public class SyncResponse implements Serializable, SyncResponseInt {
     @ApiModelProperty("Flag disabling safe settings")
     private Boolean lockSafeSettings;
 
-    @ApiModelProperty("Require additional permissions")
-    private Boolean mobileRequireAdditionalPermissions;
+    @ApiModelProperty("Skip permissions that require user interaction")
+    private Boolean skipUserInteractivePermissions;
 
     @ApiModelProperty("Flag enabling permissive mode")
     private Boolean permissive;

--- a/server/src/main/java/com/hmdm/rest/json/SyncResponse.java
+++ b/server/src/main/java/com/hmdm/rest/json/SyncResponse.java
@@ -121,6 +121,9 @@ public class SyncResponse implements Serializable, SyncResponseInt {
     @ApiModelProperty("Flag disabling safe settings")
     private Boolean lockSafeSettings;
 
+    @ApiModelProperty("Require additional permissions")
+    private Boolean mobileRequireAdditionalPermissions;
+
     @ApiModelProperty("Flag enabling permissive mode")
     private Boolean permissive;
 
@@ -758,10 +761,19 @@ public class SyncResponse implements Serializable, SyncResponseInt {
         this.lockSafeSettings = lockSafeSettings;
     }
 
+    public void setMobileRequireAdditionalPermissions(boolean mobileRequireAdditionalPermissions) {
+        this.mobileRequireAdditionalPermissions = mobileRequireAdditionalPermissions;
+    }
+
+    public Boolean getMobileRequireAdditionalPermissions() {
+        return mobileRequireAdditionalPermissions;
+    }
+
     @Override
     public Boolean getPermissive() {
         return permissive;
     }
+
 
     public void setPermissive(Boolean permissive) {
         this.permissive = permissive;

--- a/server/src/main/java/com/hmdm/rest/resource/SyncResource.java
+++ b/server/src/main/java/com/hmdm/rest/resource/SyncResource.java
@@ -387,6 +387,7 @@ public class SyncResource {
         data.setAllowedClasses(configuration.getAllowedClasses());
         data.setNewServerUrl(configuration.getNewServerUrl());
         data.setLockSafeSettings(configuration.getLockSafeSettings());
+        data.setMobileRequireAdditionalPermissions(configuration.isMobileRequireAdditionalPermissions());
         data.setPermissive(configuration.getPermissive());
         data.setKioskExit(configuration.getKioskExit());
         data.setShowWifi(configuration.getShowWifi());

--- a/server/src/main/java/com/hmdm/rest/resource/SyncResource.java
+++ b/server/src/main/java/com/hmdm/rest/resource/SyncResource.java
@@ -387,7 +387,7 @@ public class SyncResource {
         data.setAllowedClasses(configuration.getAllowedClasses());
         data.setNewServerUrl(configuration.getNewServerUrl());
         data.setLockSafeSettings(configuration.getLockSafeSettings());
-        data.setMobileRequireAdditionalPermissions(configuration.isMobileRequireAdditionalPermissions());
+        data.setSkipUserInteractivePermissions(configuration.getSkipUserInteractivePermissions());
         data.setPermissive(configuration.getPermissive());
         data.setKioskExit(configuration.getKioskExit());
         data.setShowWifi(configuration.getShowWifi());

--- a/server/src/main/resources/liquibase/db.changelog.xml
+++ b/server/src/main/resources/liquibase/db.changelog.xml
@@ -2157,10 +2157,10 @@
     <changeSet id="21.09.23-19:04" author="eretl" context="common">
         <comment>Add mobile entrollment column to configurations</comment>
         <sql>
-            ALTER TABLE configurations ADD COLUMN mobileRequireAdditionalPermissions BOOLEAN NOT NULL DEFAULT false;
+            ALTER TABLE configurations ADD COLUMN skipUserInteractivePermissions BOOLEAN NOT NULL DEFAULT false;
         </sql>
         <rollback>
-            ALTER TABLE configurations DROP COLUMN mobileRequireAdditionalPermissions;
+            ALTER TABLE configurations DROP COLUMN skipUserInteractivePermissions;
         </rollback>
     </changeSet>
 

--- a/server/src/main/resources/liquibase/db.changelog.xml
+++ b/server/src/main/resources/liquibase/db.changelog.xml
@@ -2154,6 +2154,16 @@
         </rollback>
     </changeSet>
 
+    <changeSet id="21.09.23-19:04" author="eretl" context="common">
+        <comment>Add mobile entrollment column to configurations</comment>
+        <sql>
+            ALTER TABLE configurations ADD COLUMN mobileRequireAdditionalPermissions BOOLEAN NOT NULL DEFAULT false;
+        </sql>
+        <rollback>
+            ALTER TABLE configurations DROP COLUMN mobileRequireAdditionalPermissions;
+        </rollback>
+    </changeSet>
+
     <changeSet id="05.09.21-13:44" author="seva" context="common">
         <comment>Add permission to send Push via API</comment>
         <sql>

--- a/server/src/main/webapp/app/components/main/view/configuration.html
+++ b/server/src/main/webapp/app/components/main/view/configuration.html
@@ -839,9 +839,9 @@
                     </div>
 
                     <div class='form-group'>
-                        <label class='col-sm-3 control-label' localized>form.configuration.settings.mdm.mobile.requireadditionalpermissions</label>
+                        <label class='col-sm-3 control-label' localized>form.configuration.settings.mdm.mobile.skipUserInteractivePermissions</label>
                         <div class='col-sm-1'>
-                            <input ng-model='configuration.mobileRequireAdditionalPermissions' name="RequireAdditionalPermissions-c" type='checkbox' class='form-control'/>
+                            <input ng-model='configuration.skipUserInteractivePermissions' name="SkipUserInteractivePermissions-c" type='checkbox' class='form-control'/>
                         </div>
                     </div>
 

--- a/server/src/main/webapp/app/components/main/view/configuration.html
+++ b/server/src/main/webapp/app/components/main/view/configuration.html
@@ -838,6 +838,14 @@
                         </div>
                     </div>
 
+                    <div class='form-group'>
+                        <label class='col-sm-3 control-label' localized>form.configuration.settings.mdm.mobile.requireadditionalpermissions</label>
+                        <div class='col-sm-1'>
+                            <input ng-model='configuration.mobileRequireAdditionalPermissions' name="RequireAdditionalPermissions-c" type='checkbox' class='form-control'/>
+                        </div>
+                    </div>
+
+
                     <div ng-if="!configuration.kioskMode">
 
                     <div class='form-group'>

--- a/server/src/main/webapp/localization/en_US.js
+++ b/server/src/main/webapp/localization/en_US.js
@@ -280,6 +280,7 @@ document.localization ['en_US'] = {
     'form.configuration.settings.mdm.mobile.enrollment': 'Enroll using mobile data',
     'form.configuration.settings.mdm.lock.safe.settings': 'Lock safe settings (WiFi, GPS, etc)',
     'form.configuration.settings.mdm.permissive': 'Permissive (unlocked) mode',
+    'form.configuration.settings.mdm.mobile.requireadditionalpermissions': 'Require additional permissions (Screen overlay, System diagnostics, Accesibility Service)',
     'form.configuration.settings.mdm.kiosk.exit': 'Kiosk exit button',
     'form.configuration.settings.mdm.allowed.classes': 'Allowed activities',
     'form.configuration.settings.mdm.allowed.classes.placeholder': 'Comma-separated classes, e.g.: com.android.settings.homepage.SettingsHomepageActivity',

--- a/server/src/main/webapp/localization/en_US.js
+++ b/server/src/main/webapp/localization/en_US.js
@@ -280,7 +280,7 @@ document.localization ['en_US'] = {
     'form.configuration.settings.mdm.mobile.enrollment': 'Enroll using mobile data',
     'form.configuration.settings.mdm.lock.safe.settings': 'Lock safe settings (WiFi, GPS, etc)',
     'form.configuration.settings.mdm.permissive': 'Permissive (unlocked) mode',
-    'form.configuration.settings.mdm.mobile.requireadditionalpermissions': 'Require additional permissions (Screen overlay, System diagnostics, Accesibility Service)',
+    'form.configuration.settings.mdm.mobile.skipUserInteractivePermissions': 'Skip permissions that require user interaction (Screen overlay, System diagnostics, Accesibility Service)',
     'form.configuration.settings.mdm.kiosk.exit': 'Kiosk exit button',
     'form.configuration.settings.mdm.allowed.classes': 'Allowed activities',
     'form.configuration.settings.mdm.allowed.classes.placeholder': 'Comma-separated classes, e.g.: com.android.settings.homepage.SettingsHomepageActivity',


### PR DESCRIPTION
I have added option to MDM settings section. That will skip asking for permissions that need user input on pro version. 
Alternation of (https://github.com/h-mdm/hmdm-android/pull/17)
Would this be accaptable? Or perhaps if it was reversed as "Skip permissions that need user input" instead of "Require additional permissions"?