### PR TITLE
v5.34.3 Fixed empty MDM field in the config tab

### DIFF
--- a/server/src/main/webapp/app/app.js
+++ b/server/src/main/webapp/app/app.js
@@ -47,7 +47,7 @@ angular.module('headwind-kiosk',
     .constant("LOCALIZATION_BUNDLES", [
         'en_US', 'ru_RU', 'fr_FR', 'pt_PT', 'ar_AE', 'es_ES', 'de_DE',
         'zh_TW', 'zh_CN', 'ja_JP', 'tr_TR', 'it_IT'])
-    .constant("APP_VERSION", "5.34.2") // Update this value on each commit
+    .constant("APP_VERSION", "5.34.3") // Update this value on each commit
     .constant("ENGLISH", "en_US")
     .provider('getBrowserLanguage', function (ENGLISH, SUPPORTED_LANGUAGES) {
         this.f = function () {


### PR DESCRIPTION
The patch fixes a bug where the MDM application field became empty.

Changes:
- Added timeout to allow configuration synchronization to complete;
- Added flag `bConfigurationWasLost` to prevent configuration corruption;
- Bumped version.

Known issue: the MDM application may sometimes appear with a delay of a few seconds.