### PR TITLE
[JWT] Enable Shared JWT Configuration for Tomcat Cluster Authentication

### DIFF
--- a/install/context_template.xml
+++ b/install/context_template.xml
@@ -86,4 +86,8 @@
     <Parameter name="email.recovery.subj" value="_BASE_DIRECTORY_/emails/_LANGUAGE_/recovery_subj.txt"/>
     <Parameter name="email.recovery.body" value="_BASE_DIRECTORY_/emails/_LANGUAGE_/recovery_body.txt"/>
 
+    <!-- JWT parameters are allow you to customise secret and validity token -->
+    <!-- <Parameter name="jwt.secretkey" value="20c68f0d9185b1d18cf6add1e8b491fd89529a44"/> -->
+    <!-- <Parameter name="jwt.validity" value="86400"/> -->
+    <!-- <Parameter name="jwt.validityrememberme" value="2592000"/> -->
 </Context>

--- a/jwt/pom.xml
+++ b/jwt/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <name>JWT Auth for MDM API</name>
 
     <parent>
@@ -37,6 +37,13 @@
     </parent>
 
     <dependencies>
+        <!-- Guice DI framework -->
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>${guice.version}</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/jwt/src/main/java/com/hmdm/security/jwt/TokenProvider.java
+++ b/jwt/src/main/java/com/hmdm/security/jwt/TokenProvider.java
@@ -24,8 +24,10 @@ package com.hmdm.security.jwt;
 import java.io.IOException;
 import java.util.Date;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hmdm.util.CryptoUtil;
+import com.hmdm.util.StringUtil;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -37,6 +39,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.hmdm.persistence.domain.User;
+
+import javax.inject.Named;
 
 /**
  * <p>A provider for JWT tokens.</p>
@@ -71,12 +75,27 @@ public class TokenProvider {
     /**
      * <p>Constructs new <code>TokenProvider</code> instance with specified configuration.</p>
      */
-    public TokenProvider() {
-        // Use hardcoded secret key for debugging purposes only
-        //this.secretKey = "20c68f0d9185b1d18cf6add1e8b491fd89529a44";
-        this.secretKey = CryptoUtil.randomHexString(40);
-        this.tokenValidityInMilliseconds = 1000 * 86400; // 24 hours
-        this.tokenValidityInMillisecondsForRememberMe = 1000 * 2592000L; // 30 days
+    @Inject
+    public TokenProvider(@Named("jwt.secretkey") String jwtSecretKey,
+                         @Named("jwt.validity") String jwtValidity,
+                         @Named("jwt.validityrememberme") String jwtValidityForRememberMe) {
+        long defaultValidity = 86400; // 24 hours
+        long defaultValidityForRememberMe = 2592000; // 30 days
+        String defaultSecretKey = CryptoUtil.randomHexString(40);
+
+        if (!StringUtil.isEmpty(jwtSecretKey)) {
+            defaultSecretKey = jwtSecretKey;
+        }
+        if (!StringUtil.isEmpty(jwtValidity)) {
+            defaultValidity = Long.parseLong(jwtValidity);
+        }
+        if (!StringUtil.isEmpty(jwtValidityForRememberMe)) {
+            defaultValidityForRememberMe = Long.parseLong(jwtValidityForRememberMe);
+        }
+
+        this.secretKey = defaultSecretKey;
+        this.tokenValidityInMilliseconds = 1000L * defaultValidity;
+        this.tokenValidityInMillisecondsForRememberMe = 1000L * defaultValidityForRememberMe;
     }
 
     /**

--- a/plugins/platform/pom.xml
+++ b/plugins/platform/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.hmdm</groupId>
             <artifactId>jwt</artifactId>
-            <version>0.1.0</version>
+            <version>0.2.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.github.classgraph/classgraph -->

--- a/server/build.properties.example
+++ b/server/build.properties.example
@@ -66,3 +66,8 @@ smtp.starttls=0
 smtp.username=myacct@example.com
 smtp.password=skcbh252235as
 smtp.from=noreply@example.com
+
+# JWT Config secret and token validity
+jwt.secretkey=20c68f0d9185b1d18cf6add1e8b491fd89529a44
+jwt.validity=86400
+jwt.validityrememberme=2592000

--- a/server/conf/context.xml
+++ b/server/conf/context.xml
@@ -82,4 +82,8 @@
     Defaults to X-Real-IP -->
     <!-- <Parameter name="proxy.ip.header" value="${proxy.ip.header}"/> -->
 
+    <!-- JWT parameters are allow you to customise secret and validity token -->
+    <!-- <Parameter name="jwt.secretkey" value="${jwt.secretkey}"/> -->
+    <!-- <Parameter name="jwt.validity" value="${jwt.validity}"/> -->
+    <!-- <Parameter name="jwt.validityrememberme" value="${jwt.validityrememberme}"/> -->
 </Context>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.hmdm</groupId>
             <artifactId>jwt</artifactId>
-            <version>0.1.0</version>
+            <version>0.2.0</version>
         </dependency>
 
         <dependency>

--- a/server/src/main/java/com/hmdm/guice/module/ConfigureModule.java
+++ b/server/src/main/java/com/hmdm/guice/module/ConfigureModule.java
@@ -95,6 +95,9 @@ public class ConfigureModule extends AbstractModule {
     private final String deviceAllowedAddress = "device.allowed.address";
     private final String uiAllowedAddress = "ui.allowed.address";
     private final String apkTrustedUrlParameter = "apk.trusted.url";
+    private final String jwtSecretKey = "jwt.secretkey";
+    private final String jwtValidity = "jwt.validity";
+    private final String jwtValidityForRememberMe = "jwt.validityrememberme";
     private final ServletContext context;
 
     public ConfigureModule(ServletContext context) {
@@ -263,5 +266,11 @@ public class ConfigureModule extends AbstractModule {
         this.bindConstant().annotatedWith(Names.named(uiAllowedAddress)).to(opt != null ? opt : "");
         opt = this.context.getInitParameter(apkTrustedUrlParameter);
         this.bindConstant().annotatedWith(Names.named(apkTrustedUrlParameter)).to(opt != null ? opt : "");
+        opt = this.context.getInitParameter(jwtSecretKey);
+        this.bindConstant().annotatedWith(Names.named(jwtSecretKey)).to(opt != null ? opt : "");
+        opt = this.context.getInitParameter(jwtValidity);
+        this.bindConstant().annotatedWith(Names.named(jwtValidity)).to(opt != null ? opt : "");
+        opt = this.context.getInitParameter(jwtValidityForRememberMe);
+        this.bindConstant().annotatedWith(Names.named(jwtValidityForRememberMe)).to(opt != null ? opt : "");
     }
 }


### PR DESCRIPTION
# Context
While configuring a Tomcat cluster for the MDM server, we encountered an issue with JWT-based authentication through the REST API. The JWT signing secret was being generated dynamically at the instance level, which caused token validation failures across different nodes in the cluster.

# Problem
Since each instance maintained its own secret, tokens generated by one node could not be validated by others, breaking authentication in a distributed setup.

# Solution
This PR introduces a mechanism to externalize and dynamically configure the JWT secret. The secret can now be shared across all Tomcat instances, ensuring consistent token generation and validation throughout the cluster.

# Impact
- Enables proper JWT authentication in clustered environments.
- Improves scalability and reliability of the MDM server.
- Reduces risk of token validation errors due to inconsistent secrets.