### PR TITLE
Added UTF-8 support to QR code generation

### DIFF
--- a/server/src/main/java/com/hmdm/rest/resource/QRCodeResource.java
+++ b/server/src/main/java/com/hmdm/rest/resource/QRCodeResource.java
@@ -273,7 +273,7 @@ public class QRCodeResource {
                                 imageSize = size;
                             }
                             try {
-                                QRCode.from(s).to(ImageType.PNG).withSize(imageSize, imageSize).writeTo(output);
+                                QRCode.from(s).withCharset("UTF-8").to(ImageType.PNG).withSize(imageSize, imageSize).writeTo(output);
                                 output.flush();
                             } catch ( Exception e ) { e.printStackTrace(); }
                         } )


### PR DESCRIPTION
QR code generation currently does not support UTF-8. This can cause issues, for example, if your Configuration includes a wifi SSID with non-ASCII characters; they will instead be encoded as ? characters in the resulting QR code image.

This PR changes one line so that QR codes are generated with UTF-8 support. Compiled and tested working on my deployment.